### PR TITLE
Adding the ability to inject CRD creation type overrides 

### DIFF
--- a/src/KubeOps/Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps/Operator/Builder/OperatorBuilder.cs
@@ -229,6 +229,9 @@ internal class OperatorBuilder : IOperatorBuilder
         Services.TryAddSingleton<ICrdBuilder, CrdBuilder>();
         Services.TryAddSingleton<IRbacBuilder, RbacBuilder>();
 
+        // Register type overrides register.
+        Services.TryAddSingleton<ICrdBuilderTypeOverrides, CrdBuilderTypeOverrides>();
+
         return this;
     }
 }

--- a/src/KubeOps/Operator/Entities/CrdBuilder.cs
+++ b/src/KubeOps/Operator/Entities/CrdBuilder.cs
@@ -10,10 +10,12 @@ namespace KubeOps.Operator.Entities;
 internal class CrdBuilder : ICrdBuilder
 {
     private readonly IComponentRegistrar _componentRegistrar;
+    private readonly ICrdBuilderTypeOverrides? _crdBuilderOverrides;
 
-    public CrdBuilder(IComponentRegistrar componentRegistrar)
+    public CrdBuilder(IComponentRegistrar componentRegistrar, ICrdBuilderTypeOverrides? crdBuilderOverrides = null)
     {
         _componentRegistrar = componentRegistrar;
+        _crdBuilderOverrides = crdBuilderOverrides;
     }
 
     public IEnumerable<V1CustomResourceDefinition> BuildCrds() =>
@@ -22,7 +24,7 @@ internal class CrdBuilder : ICrdBuilder
             .Where(type => type.Assembly != typeof(KubernetesEntityAttribute).Assembly)
             .Where(type => type.GetCustomAttributes<KubernetesEntityAttribute>().Any())
             .Where(type => !type.GetCustomAttributes<IgnoreEntityAttribute>().Any())
-            .Select(type => (type.CreateCrd(), type.GetCustomAttributes<StorageVersionAttribute>().Any()))
+            .Select(type => (type.CreateCrd(_crdBuilderOverrides), type.GetCustomAttributes<StorageVersionAttribute>().Any()))
             .GroupBy(grp => grp.Item1.Metadata.Name)
             .Select(
                 group =>

--- a/src/KubeOps/Operator/Entities/CrdBuilderTypeOverrides.cs
+++ b/src/KubeOps/Operator/Entities/CrdBuilderTypeOverrides.cs
@@ -1,0 +1,21 @@
+namespace KubeOps.Operator.Entities;
+
+internal class CrdBuilderTypeOverrides : ICrdBuilderTypeOverrides
+{
+    public CrdBuilderTypeOverrides(IEnumerable<ICrdBuilderTypeOverride> typeOverrides)
+    {
+        TypeOverrides = typeOverrides;
+    }
+
+    private IEnumerable<ICrdBuilderTypeOverride> TypeOverrides { get; }
+
+    public ICrdBuilderTypeOverride? GetMatchingTypeOverride(Type type, string? jsonPath) =>
+
+        // First check if jsonPaths match. Should only ever return single or null
+        TypeOverrides
+            .SingleOrDefault(ovrd => ovrd.TargetJsonPath == jsonPath && ovrd.TargetJsonPath != null)
+
+        // If none of the jsonPaths matched, then match by type only for objects where jsonPath has not been defined
+        ?? TypeOverrides
+            .SingleOrDefault(ovrd => ovrd.TypeMatchesOverrideCondition(type) && ovrd.TargetJsonPath == null);
+}

--- a/src/KubeOps/Operator/Entities/ICrdBuilderTypeOverrides.cs
+++ b/src/KubeOps/Operator/Entities/ICrdBuilderTypeOverrides.cs
@@ -1,0 +1,42 @@
+using k8s.Models;
+
+namespace KubeOps.Operator.Entities;
+
+/// <summary>
+/// Interface representing a set of type overrides for CRD generation.
+/// </summary>
+public interface ICrdBuilderTypeOverrides
+{
+    /// <summary>
+    /// Returns the override condition/action pair that matches user defined condition.
+    /// </summary>
+    /// <param name="type">Type being checked against.</param>
+    /// <param name="jsonpath">The specific schema jsonpath being checked against.</param>
+    /// <returns>The override containing a possible JsonPath, type match condition, and action on the property.</returns>
+    public ICrdBuilderTypeOverride? GetMatchingTypeOverride(Type type, string jsonpath);
+}
+
+/// <summary>
+/// The override definition class which sets the condition for which the type should be overridden during CRD generation,
+/// and what should the serialized values map to.
+/// </summary>
+public interface ICrdBuilderTypeOverride
+{
+    /// <summary>
+    /// Target JSON path on the CRD schema.
+    /// </summary>
+    public string? TargetJsonPath { get; }
+
+    /// <summary>
+    /// Checks if the type matches the user defined condition that will custom configure the schema property for the given type.
+    /// </summary>
+    /// <param name="type">Type being checked against.</param>
+    /// <returns>Boolean determining whether the user defined type condition has been matched.</returns>
+    public bool TypeMatchesOverrideCondition(Type type);
+
+    /// <summary>
+    /// For the matching condition, configure the CRD property in a user defined way for the given type.
+    /// </summary>
+    /// <param name="props">The object type that will be converted to a schema.</param>
+    public void ConfigureCustomSchemaForProp(V1JSONSchemaProps props);
+}

--- a/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
+++ b/tests/KubeOps.Test/Operator/Generators/CrdGenerator.Test.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Reflection;
+using FluentAssertions;
+using k8s;
 using k8s.Models;
 using KubeOps.Operator.Builder;
 using KubeOps.Operator.Entities;
@@ -10,34 +12,34 @@ namespace KubeOps.Test.Operator.Generators;
 public class CrdGeneratorTest
 {
     private readonly IEnumerable<V1CustomResourceDefinition> _crds;
+    private readonly ComponentRegistrar _componentRegistrar = new();
 
     public CrdGeneratorTest()
     {
-        var componentRegistrar = new ComponentRegistrar();
-
-        componentRegistrar.RegisterEntity<TestIgnoredEntity>();
-        componentRegistrar.RegisterEntity<TestInvalidEntity>();
-        componentRegistrar.RegisterEntity<TestSpecEntity>();
-        componentRegistrar.RegisterEntity<TestClusterSpecEntity>();
-        componentRegistrar.RegisterEntity<TestStatusEntity>();
-        componentRegistrar.RegisterEntity<V1Alpha1VersionedEntity>();
-        componentRegistrar.RegisterEntity<V1AttributeVersionedEntity>();
-        componentRegistrar.RegisterEntity<V1Beta1VersionedEntity>();
-        componentRegistrar.RegisterEntity<V1VersionedEntity>();
-        componentRegistrar.RegisterEntity<V2AttributeVersionedEntity>();
-        componentRegistrar.RegisterEntity<V2Beta2VersionedEntity>();
-        componentRegistrar.RegisterEntity<V2VersionedEntity>();
+        _componentRegistrar.RegisterEntity<TestIgnoredEntity>();
+        _componentRegistrar.RegisterEntity<TestInvalidEntity>();
+        _componentRegistrar.RegisterEntity<TestSpecEntity>();
+        _componentRegistrar.RegisterEntity<TestClusterSpecEntity>();
+        _componentRegistrar.RegisterEntity<TestStatusEntity>();
+        _componentRegistrar.RegisterEntity<V1Alpha1VersionedEntity>();
+        _componentRegistrar.RegisterEntity<V1AttributeVersionedEntity>();
+        _componentRegistrar.RegisterEntity<V1Beta1VersionedEntity>();
+        _componentRegistrar.RegisterEntity<V1VersionedEntity>();
+        _componentRegistrar.RegisterEntity<V2AttributeVersionedEntity>();
+        _componentRegistrar.RegisterEntity<V2Beta2VersionedEntity>();
+        _componentRegistrar.RegisterEntity<V2VersionedEntity>();
+        _componentRegistrar.RegisterEntity<TestCustomCrdTypeOverrides>();
 
         // Should be ignored since V1Pod is from the k8s assembly.
-        componentRegistrar.RegisterEntity<V1Pod>();
+        _componentRegistrar.RegisterEntity<V1Pod>();
 
-        _crds = new CrdBuilder(componentRegistrar).BuildCrds();
+        _crds = new CrdBuilder(_componentRegistrar).BuildCrds();
     }
 
     [Fact]
     public void Should_Generate_Correct_Number_Of_Crds()
     {
-        _crds.Count().Should().Be(5);
+        _crds.Count().Should().Be(6);
     }
 
     [Fact]
@@ -100,5 +102,84 @@ public class CrdGeneratorTest
             .NotBeNull()
             .And
             .Contain(new[] { "foo", "bar", "baz" });
+    }
+
+    [Fact]
+    public void Should_Create_Crd_As_Default_Without_Crd_Type_Overrides()
+    {
+        var crdWithoutOverrides = new CrdBuilder(_componentRegistrar)
+            .BuildCrds()
+            .First(
+
+                c => c.Spec.Names.Kind.Contains("testcustomtypeoverrides", StringComparison.InvariantCultureIgnoreCase));
+        var serializedWithoutOverrides = KubernetesYaml.Serialize(crdWithoutOverrides);
+
+        serializedWithoutOverrides.Should().Contain(TestTypeOverridesValues.ExpectedDefaultYamlResources);
+        serializedWithoutOverrides.Should().NotContain(TestTypeOverridesValues.ExpectedOverriddenResourcesYaml);
+        serializedWithoutOverrides.Should().NotContain(TestTypeOverridesValues.ExpectedOverriddenResourcesWithJsonPathYaml);
+    }
+
+    [Fact]
+    public void Should_Convert_Desired_Crd_Type_To_Desired_Crd_Format()
+    {
+        var customOverrides = new CrdBuilderTypeOverrides(new List<ICrdBuilderTypeOverride> { new TestTypeOverride() });
+        var crdWithTypeOverrides = new CrdBuilder(_componentRegistrar, customOverrides)
+            .BuildCrds()
+            .First(
+                c => c.Spec.Names.Kind.Contains("testcustomtypeoverrides", StringComparison.InvariantCultureIgnoreCase));
+        var serializedWithOverrides = KubernetesYaml.Serialize(crdWithTypeOverrides);
+
+        serializedWithOverrides.Should().Contain(TestTypeOverridesValues.ExpectedOverriddenResourcesYaml);
+        serializedWithOverrides.Should().NotContain(TestTypeOverridesValues.ExpectedDefaultYamlResources);
+
+    }
+
+    [Fact]
+    public void Should_Convert_Desired_Crd_Type_To_Desired_Crd_Format_Matching_JsonPath()
+    {
+        var customOverridesWithJsonPath = new CrdBuilderTypeOverrides(new List<ICrdBuilderTypeOverride>
+        {
+            new TestTypeOverride(),
+            new TestTypeOverrideWithJsonpath(".spec.objectName.resources.limits")
+        });
+        var crdWithTypeOverridesAndJsonPath = new CrdBuilder(_componentRegistrar, customOverridesWithJsonPath)
+            .BuildCrds()
+            .First(
+                c => c.Spec.Names.Kind.Contains("testcustomtypeoverrides", StringComparison.InvariantCultureIgnoreCase));
+        var serializedWithOverridesAndJsonPath = KubernetesYaml.Serialize(crdWithTypeOverridesAndJsonPath);
+        serializedWithOverridesAndJsonPath.Should().Contain(TestTypeOverridesValues.ExpectedOverriddenResourcesWithJsonPathYaml);
+    }
+
+
+    [Fact]
+    public void Should_Convert_Desired_Crd_Type_To_Desired_Crd_Format_Matching_Multiple_JsonPaths()
+    {
+        var customOverridesWithJsonPath = new CrdBuilderTypeOverrides(new List<ICrdBuilderTypeOverride>
+        {
+            new TestTypeOverride(),
+            new TestTypeOverrideWithJsonpath(".spec.objectName.resources.limits"),
+            new TestTypeOverrideWithJsonpath(".spec.objectName.resources.claims"),
+        });
+        var crdWithTypeOverridesAndJsonPath = new CrdBuilder(_componentRegistrar, customOverridesWithJsonPath)
+            .BuildCrds()
+            .First(
+                c => c.Spec.Names.Kind.Contains("testcustomtypeoverrides", StringComparison.InvariantCultureIgnoreCase));
+        var serializedWithOverridesAndJsonPath = KubernetesYaml.Serialize(crdWithTypeOverridesAndJsonPath);
+        serializedWithOverridesAndJsonPath.Should().Contain(TestTypeOverridesValues.ExpectedOverriddenResourcesWithMultipleJsonPathsYaml);
+    }
+
+    [Fact]
+    public void Should_Control_Whole_Crd_Spec_Using_JsonPath_Overrides()
+    {
+        var customOverridesWithJsonPath = new CrdBuilderTypeOverrides(new List<ICrdBuilderTypeOverride>
+        {
+            new TestTypeOverrideWithJsonpath(""),
+        });
+        var crdWithTypeOverridesAndJsonPath = new CrdBuilder(_componentRegistrar, customOverridesWithJsonPath)
+            .BuildCrds()
+            .First(
+                c => c.Spec.Names.Kind.Contains("testcustomtypeoverrides", StringComparison.InvariantCultureIgnoreCase));
+        var serializedWithOverridesAndJsonPath = KubernetesYaml.Serialize(crdWithTypeOverridesAndJsonPath);
+        serializedWithOverridesAndJsonPath.Should().Contain(TestTypeOverridesValues.ExpectedWholeControlledSchemaWithJsonPath);
     }
 }

--- a/tests/KubeOps.Test/TestEntities/TestCustomCrdTypeOverrides.cs
+++ b/tests/KubeOps.Test/TestEntities/TestCustomCrdTypeOverrides.cs
@@ -1,0 +1,174 @@
+using k8s.Models;
+using KubeOps.Operator.Entities;
+
+namespace KubeOps.Test.TestEntities;
+
+public class TestStatus
+{
+    public string SpecString { get; set; } = string.Empty;
+}
+
+public class TestResourceRequirements
+{
+    public V1ResourceRequirements Resources { get; set; } = new();
+}
+
+public class TestSpec
+{
+    public TestResourceRequirements ObjectName { get; set; } = new();
+    public DateTime LastModified { get; set; }
+}
+
+[KubernetesEntity(
+    ApiVersion = "v1",
+    Kind = "TestCustomTypeOverrides",
+    Group = "kubeops.test.dev",
+    PluralName = "testcustomtypeoverrides")]
+public class TestCustomCrdTypeOverrides : CustomKubernetesEntity<TestSpec, TestStatus>
+{
+}
+
+public class TestTypeOverride : ICrdBuilderTypeOverride
+{
+
+    public bool TypeMatchesOverrideCondition(Type type) => type.IsGenericType
+                                                           && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                                                           && type.GenericTypeArguments.Contains(typeof(ResourceQuantity));
+    public void ConfigureCustomSchemaForProp(V1JSONSchemaProps props)
+    {
+        props.Type = "object";
+        props.XKubernetesPreserveUnknownFields = true;
+        props.Description = "";
+    }
+
+    public string? TargetJsonPath => null; // apply to everything
+}
+
+public class TestTypeOverrideWithJsonpath : ICrdBuilderTypeOverride
+{
+    public TestTypeOverrideWithJsonpath(string jsonpath)
+    {
+        TargetJsonPath = jsonpath;
+    }
+    public bool TypeMatchesOverrideCondition(Type type) => type.IsGenericType
+                                                           && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                                                           && type.GenericTypeArguments.Contains(typeof(ResourceQuantity));
+    public void ConfigureCustomSchemaForProp(V1JSONSchemaProps props)
+    {
+        props.Type = "test-with-jsonpath";
+        props.Description = "";
+
+        if (TargetJsonPath == "")
+        {
+            props.Properties = new Dictionary<string, V1JSONSchemaProps>
+            {
+                ["test-full-schema-control"] = new () { Type = "test-nested-property" }
+            };
+        }
+
+    }
+
+    public string TargetJsonPath { get; }
+}
+
+public static class TestTypeOverridesValues
+{
+    public const string ExpectedOverriddenResourcesYaml = @"
+                      limits:
+                        description: """"
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      requests:
+                        description: """"
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true";
+
+    public const string ExpectedOverriddenResourcesWithJsonPathYaml = @"
+                      limits:
+                        description: """"
+                        type: test-with-jsonpath
+                      requests:
+                        description: """"
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true";
+
+    public const string ExpectedOverriddenResourcesWithMultipleJsonPathsYaml = @"
+                      claims:
+                        description: """"
+                        type: test-with-jsonpath
+                      limits:
+                        description: """"
+                        type: test-with-jsonpath
+                      requests:
+                        description: """"
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object";
+
+    public const string ExpectedWholeControlledSchemaWithJsonPath = @"
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: """"
+        properties:
+          test-full-schema-control:
+            type: test-nested-property
+        type: test-with-jsonpath
+";
+
+    public const string ExpectedDefaultYamlResources = @"
+                  resources:
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims, that are
+                          used by this container.
+
+                          This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate.
+
+                          This field is immutable.
+                        items:
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of the Pod
+                                where this field is used. It makes that resource available inside a container.
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          properties:
+                            format:
+                              enum:
+                              - DecimalExponent
+                              - BinarySI
+                              - DecimalSI
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed. More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          properties:
+                            format:
+                              enum:
+                              - DecimalExponent
+                              - BinarySI
+                              - DecimalSI
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        description: |-
+                          Requests describes the minimum amount of compute resources required. If Requests
+                          is omitted for a container, it defaults to Limits if that is explicitly
+                          specified, otherwise to an implementation-defined value. More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object";
+}


### PR DESCRIPTION
Adding the ability to inject CRD creation type overrides into the container that will allow user defined CRD schema format

This gives the user a greater degree of control over the CRD schema generation.